### PR TITLE
"BOOST_SYSTEM_NOEXCEPT does not name a type" fix

### DIFF
--- a/lazy_bdecode.cpp
+++ b/lazy_bdecode.cpp
@@ -35,6 +35,10 @@ POSSIBILITY OF SUCH DAMAGE.
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+#ifndef BOOST_SYSTEM_NOEXCEPT
+	#define BOOST_SYSTEM_NOEXCEPT BOOST_NOEXCEPT
+#endif
+
 namespace
 {
 	const int lazy_entry_grow_factor = 150; // percent


### PR DESCRIPTION
Compilation fails when boost version is 1.49:
```
lazy_bdecode.cpp:558:30: error: expected ‘;’ at end of member declaration
lazy_bdecode.cpp:558:36: error: ‘BOOST_SYSTEM_NOEXCEPT’ does not name a type
lazy_bdecode.cpp:559:39: error: expected ‘;’ at end of member declaration
lazy_bdecode.cpp:559:45: error: ‘BOOST_SYSTEM_NOEXCEPT’ does not name a type
lazy_bdecode.cpp:560:74: error: expected ‘;’ at end of member declaration
lazy_bdecode.cpp:560:80: error: ‘BOOST_SYSTEM_NOEXCEPT’ does not name a type
lazy_bdecode.cpp:564:51: error: expected initializer before ‘BOOST_SYSTEM_NOEXCEPT’
lazy_bdecode.cpp:569:60: error: expected initializer before ‘BOOST_SYSTEM_NOEXCEPT’
lazy_bdecode.cpp:592:2: error: expected ‘}’ at end of input`
```
Added 
```
#ifndef BOOST_SYSTEM_NOEXCEPT
  #define BOOST_SYSTEM_NOEXCEPT BOOST_NOEXCEPT
#endif
```
for compatability.