### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: cpp
+
+git:
+  submodules: false
+  depth: 1
+
+cache:
+  directories:
+    - $HOME/.ccache
+
+addons:
+  apt:
+    sources:
+      - boost-latest
+      - ubuntu-toolchain-r-test
+    packages:
+      - libboost1.55-all-dev
+      - libboost1.55-tools-dev
+      - g++-5
+
+install:
+  - g++-5 --version;
+  - 'echo "using gcc : : ccache g++-5 : <cxxflags>-std=c++14 ;" > ~/user-config.jam'
+
+script:
+  - bjam -j2
+  - cd tests
+  - bjam -j2
+

--- a/bdecode.cpp
+++ b/bdecode.cpp
@@ -36,6 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <cstring> // for memset
 #include <cstdio> // for snprintf
 #include <cinttypes> // for PRId64 et.al.
+#include <cstddef> // for ptrdiff_t
 
 #include <alloca.h>
 
@@ -835,7 +836,7 @@ namespace libtorrent
 						TORRENT_FAIL_BDECODE(e);
 
 					// remaining buffer size excluding ':'
-					ptrdiff_t const buff_size = end - start - 1;
+					std::ptrdiff_t const buff_size = end - start - 1;
 					if (len > buff_size)
 						TORRENT_FAIL_BDECODE(bdecode_errors::unexpected_eof);
 					if (len < 0)


### PR DESCRIPTION
instead of using two specializations for IPv4 and IPv6, this combines them into a single template.