### PR TITLE
fix last-nodes feature by making sure they allocate some space

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -495,6 +495,8 @@ struct router_thread
 		, ping_queue6(ping_queue_size)
 		, node_buffer4(storage_filename(storage_dir, tid, false).c_str(), node_buffer_size)
 		, node_buffer6(storage_filename(storage_dir, tid, true).c_str(), node_buffer_size)
+		, last_nodes4(16)
+		, last_nodes6(16)
 		, signals(ios)
 		, threadid(tid)
 	{
@@ -872,8 +874,7 @@ struct router_thread
 			else if (len <= 0)
 				fprintf(stderr, "send_to failed: return=%d\n", len);
 
-			// filter obvious invalid IPs, and IPv6 (since we only support
-			// IPv4 for now)
+			// filter obvious invalid IPs
 			if (!is_valid_ip(ep)) return;
 
 			// don't save read-only nodes


### PR DESCRIPTION
There was no capacity allocated for the two boost circular buffers, so the push_backs() would not actually store any elements. Manually verified to work. In a future patch I'm hoping to separate the logic of router_thread from the thread itself, to allow for a unit test.