### PR TITLE
avoid redundant memcopy in node_buffer::get_nodes

### DIFF
--- a/bencode.hpp
+++ b/bencode.hpp
@@ -27,6 +27,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <cstring>
 #include <string>
 #include <algorithm>
+#include <array>
+
+#include "span.hpp"
 
 struct bencoder
 {
@@ -45,6 +48,23 @@ struct bencoder
 	void add_string(std::string const& str)
 	{
 		add_string(str.c_str(), str.length());
+	}
+
+	template <size_t N>
+	void add_string_concatenate(std::array<span<char const>, N> const& ranges)
+	{
+		size_t len = 0;
+		for (auto const& r : ranges) len += r.size();
+
+		m_buf += std::snprintf(m_buf, m_end - m_buf, "%zu:", len);
+
+		if (m_end - m_buf < len) return;
+
+		for (auto const& r : ranges) {
+			if (r.empty()) continue;
+			memcpy(m_buf, r.data(), r.size());
+			m_buf += r.size();
+		}
 	}
 	char* end() const { return m_buf; }
 

--- a/node_buffer.hpp
+++ b/node_buffer.hpp
@@ -81,7 +81,7 @@ struct node_buffer
 	std::array<span<char const>, 2>
 	get_nodes(int const num_nodes)
 	{
-		if (m_buffer.size() < num_nodes)
+		if (m_buffer.size() <= num_nodes)
 		{
 			// this is the case where we have fewer nodes in the node_buffer than
 			// we want to send in a single response

--- a/span.hpp
+++ b/span.hpp
@@ -1,0 +1,55 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2016 Arvid Norberg
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+
+#pragma once
+
+#include <string>
+
+// TODO: at some point it probably makes sense to pull in GSL's span instead
+template <typename T>
+struct span
+{
+	using iterator = T*;
+	using const_iterator = T const*;
+
+	span() : m_begin(nullptr), m_end(nullptr) {}
+	span(T* begin, size_t s) : m_begin(begin), m_end(m_begin + s) {}
+	span(std::basic_string<T>& str) : m_begin(str.data()), m_end(str.data() + str.size()) {}
+	template<size_t N>
+	span(T (&arr)[N]) : m_begin(arr), m_end(arr + N) {}
+
+	T* data() { return m_begin; }
+	T const* data() const { return m_begin; }
+	size_t size() const { return m_end - m_begin; }
+	bool empty() const { return m_begin == m_end; }
+
+	iterator begin() { return m_begin; }
+	iterator end() { return m_end; }
+	const_iterator begin() const { return m_begin; }
+	const_iterator end() const { return m_end; }
+private:
+	T* m_begin;
+	T* m_end;
+};
+

--- a/tests/test_node_buffer.cpp
+++ b/tests/test_node_buffer.cpp
@@ -43,19 +43,30 @@ TEST_CASE("node_buffer initial state")
 	unlink("test-node-buffer-1");
 }
 
+template <size_t N>
+bool compare(std::array<span<char const>, N> const& ranges, std::string cmp)
+{
+	for (auto const& r : ranges) {
+		if (cmp.substr(0, r.size()) != std::string(r.data(), r.size()))
+			return false;
+		cmp = cmp.substr(r.size());
+	}
+	return cmp.empty();
+}
+
 TEST_CASE("node_buffer single")
 {
 	unlink("test-node-buffer-2");
 	node_buffer<address_v4> buf("test-node-buffer-2", 10);
 
-	CHECK(buf.get_nodes(1) == std::string());
+	CHECK(compare(buf.get_nodes(1), ""));
 
 	buf.insert_node(v4::from_string("10.1.1.1"), 6881, node_id);
 
-	CHECK(buf.get_nodes(10) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1");
+	CHECK(compare(buf.get_nodes(10), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1"));
 
 	// since there's only one entry, we should get it back every time we ask
-	CHECK(buf.get_nodes(10) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1");
+	CHECK(compare(buf.get_nodes(10), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1"));
 
 	unlink("test-node-buffer-2");
 }
@@ -71,10 +82,10 @@ TEST_CASE("node_buffer duplicate")
 	buf.insert_node(v4::from_string("10.1.1.2"), 6881, node_id);
 
 	// asking for nodes should give 10.1.1.2 as many times as 10.1.1.1
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x02\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x02\x1a\xe1");
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x02\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x02\x1a\xe1"));
 
 	unlink("test-node-buffer-3");
 }
@@ -92,19 +103,19 @@ TEST_CASE("node_buffer wrap")
 	}
 
 	// asking for nodes, we should only see the last 10 nodes added
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0a\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0b\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0c\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0d\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0e\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0f\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x10\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x11\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x12\x1a\xe1");
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x13\x1a\xe1");
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0a\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0b\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0c\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0d\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0e\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0f\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x10\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x11\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x12\x1a\xe1"));
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x13\x1a\xe1"));
 
 	// and then start over again
-	CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0a\x1a\xe1");
+	CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0a\x1a\xe1"));
 
 	unlink("test-node-buffer-4");
 }
@@ -120,31 +131,31 @@ TEST_CASE("node_buffer restore")
 			buf.insert_node(v4::from_string(ip.c_str()), 6881, node_id);
 		}
 
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x02\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x03\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x04\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x05\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x06\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x07\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x08\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x09\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0a\x1a\xe1");
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x02\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x03\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x04\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x05\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x06\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x07\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x08\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x09\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0a\x1a\xe1"));
 	}
 
 	{
 		node_buffer<address_v4> buf("test-node-buffer-5", 10);
 
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x02\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x03\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x04\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x05\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x06\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x07\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x08\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x09\x1a\xe1");
-		CHECK(buf.get_nodes(1) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0a\x1a\xe1");
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x02\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x03\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x04\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x05\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x06\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x07\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x08\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x09\x1a\xe1"));
+		CHECK(compare(buf.get_nodes(1), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0a\x1a\xe1"));
 
 		// also make sure the IP unordered set used to prevent duplicates was
 		// restored
@@ -169,7 +180,7 @@ TEST_CASE("node_buffer multi-request")
 			buf.insert_node(v4::from_string(ip.c_str()), 6881, node_id);
 		}
 
-		CHECK(buf.get_nodes(10) == "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1"
+		CHECK(compare(buf.get_nodes(10), "aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x01\x1a\xe1"
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x02\x1a\xe1"
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x03\x1a\xe1"
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x04\x1a\xe1"
@@ -178,7 +189,7 @@ TEST_CASE("node_buffer multi-request")
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x07\x1a\xe1"
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x08\x1a\xe1"
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x09\x1a\xe1"
-			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0a\x1a\xe1");
+			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x0a\x1a\xe1"));
 	}
 
 	unlink("test-node-buffer-6");
@@ -200,7 +211,7 @@ TEST_CASE("node_buffer wrapping-request")
 			buf.get_nodes(1);
 		}
 
-		CHECK(buf.get_nodes(10) ==
+		CHECK(compare(buf.get_nodes(10),
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x06\x1a\xe1"
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x07\x1a\xe1"
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x08\x1a\xe1"
@@ -210,7 +221,7 @@ TEST_CASE("node_buffer wrapping-request")
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x02\x1a\xe1"
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x03\x1a\xe1"
 			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x04\x1a\xe1"
-			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x05\x1a\xe1");
+			"aaaaaaaaaaaaaaaaaaaa\x0a\x01\x01\x05\x1a\xe1"));
 	}
 
 	unlink("test-node-buffer-7");


### PR DESCRIPTION
Instead of heap allocating a string and copying nodes into, this patch makes node_buffer::get_nodes() return 2 ranges of bytes to be copied into the packet. This avoids heap allocations entirely and saves at least one memcopy for all node data.