### PR TITLE
cross pollinate feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,9 @@ The command line options are::
 	                      stored on disk. Defaults to ".".
 	--port <listen-port>  Sets the port to listen on (for all interfaces)
 	                      defaults to 6881
+	--x-pollinate <ip> <port>
+	                      if the ping queue becomes too small, request more
+	                      nodes from this DHT node.
 
 The first argument when launching the server is its own IP. This is not
 only relevant for binding the socket to this interface but is also used when

--- a/src/bencode.hpp
+++ b/src/bencode.hpp
@@ -37,6 +37,8 @@ struct bencoder
 
 	void open_dict() { if (m_buf < m_end) *m_buf++ = 'd'; }
 	void close_dict() { if (m_buf < m_end) *m_buf++ = 'e'; }
+	void open_list() { if (m_buf < m_end) *m_buf++ = 'l'; }
+	void close_list() { if (m_buf < m_end) *m_buf++ = 'e'; }
 	void add_string(char const* str, size_t len)
 	{
 		m_buf += std::snprintf(m_buf, m_end - m_buf, "%zu:", len);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -601,6 +601,13 @@ struct router_thread
 		char random_target[20];
 		std::generate(random_target, random_target + 20, &std::rand);
 		b.add_string("target"); b.add_string(random_target, sizeof(random_target));
+		b.add_string("want");
+		{
+			b.open_list();
+			b.add_string("n4");
+			b.add_string("n6");
+			b.close_list();
+		}
 		b.close_dict();
 
 		b.add_string("t"); b.add_string(transaction_id);
@@ -847,7 +854,7 @@ struct router_thread
 					std::string nodes4 = a.dict_find_string_value("nodes", "");
 					fprintf(stderr, "received %d nodes4 from x-pollinate node\n"
 						, int(nodes4.size() / 26));
-					char const* end = nodes4.data() + nodes4.size();
+					char const* end = nodes4.data() + nodes4.size() - 6 - 20;
 					for (char const* i = nodes4.data(); i < end; i += 6 + 20)
 					{
 						address_v4::bytes_type b;
@@ -862,7 +869,7 @@ struct router_thread
 					std::string nodes6 = a.dict_find_string_value("nodes6", "");
 					fprintf(stderr, "received %d nodes6 from x-pollinate node\n"
 						, int(nodes6.size() / 38));
-					char const* end = nodes6.data() + nodes6.size();
+					char const* end = nodes6.data() + nodes6.size() - 18 - 20;
 					for (char const* i = nodes6.data(); i < end; i += 18 + 20)
 					{
 						address_v6::bytes_type b;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -587,7 +587,7 @@ struct router_thread
 	{
 		char remote_ip[18];
 		size_t remote_ip_len = build_ip_field(n.ep, remote_ip);
-		std::string const transaction_id = compute_tid(secret1, remote_ip, remote_ip_len);
+		std::array<char, 4> transaction_id = compute_tid(secret1, remote_ip, remote_ip_len);
 		bound_socket& sock = socks[n.sock_idx];
 
 		// send find_nodes to this node

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -854,8 +854,8 @@ struct router_thread
 					std::string nodes4 = a.dict_find_string_value("nodes", "");
 					fprintf(stderr, "received %d nodes4 from x-pollinate node\n"
 						, int(nodes4.size() / 26));
-					char const* end = nodes4.data() + nodes4.size() - 6 - 20;
-					for (char const* i = nodes4.data(); i < end; i += 6 + 20)
+					char const* end = nodes4.data() + nodes4.size();
+					for (char const* i = nodes4.data(); end - i >= 6 + 20; i += 6 + 20)
 					{
 						address_v4::bytes_type b;
 						std::memcpy(b.data(), i, b.size());
@@ -869,8 +869,8 @@ struct router_thread
 					std::string nodes6 = a.dict_find_string_value("nodes6", "");
 					fprintf(stderr, "received %d nodes6 from x-pollinate node\n"
 						, int(nodes6.size() / 38));
-					char const* end = nodes6.data() + nodes6.size() - 18 - 20;
-					for (char const* i = nodes6.data(); i < end; i += 18 + 20)
+					char const* end = nodes6.data() + nodes6.size();
+					for (char const* i = nodes6.data(); end - i >= 18 + 20; i += 18 + 20)
 					{
 						address_v6::bytes_type b;
 						std::memcpy(b.data(), i, b.size());


### PR DESCRIPTION
This feature (when enabled) checks every 10 minutes if the ping queue is essentially empty or not. If it is (< 16 nodes), ping another bootstrap node and add the nodes returned from it in the ping queue.

I'm not very happy with this name, it was the first thing I could think of, and I'm having a hart time coming up with a better one.

Also, there aren't really any good tests for this right now (until I pull in libsimulator as a submodule and write some simulations). However, I have had this patch running in the wild for about two days now, with no hick-ups.

does it make sense?