### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN \
       libboost-system-dev \
       libboost-tools-dev \
   && \
-  bjam \
+  bjam release \
   && \
   DEBIAN_FRONTEND=noninteractive \
     apt-get -y purge --auto-remove \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:xenial
+
+COPY . /usr/src/bootstrap-dht
+WORKDIR /usr/src/bootstrap-dht
+
+RUN \
+  apt-get update && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y install \
+      build-essential \
+      libboost-dev \
+      libboost-system-dev \
+      libboost-tools-dev \
+  && \
+  bjam \
+  && \
+  DEBIAN_FRONTEND=noninteractive \
+    apt-get -y purge --auto-remove \
+      build-essential \
+  && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/
+
+ENTRYPOINT [ "./dht-bootstrap" ]


### PR DESCRIPTION
Add Dockerfile to enable image building.
Using the official Ubuntu, latest Xenial LTS series tag. More info at https://hub.docker.com/_/ubuntu/

Build:
```
$ docker build -t bootstrap-dht .
```

Run:
```
$ docker run -dit --name dht --net=host bootstrap-dht [options...]
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:
```
$ docker run --rm -it --name dht --net=host pataquets/bootstrap-dht [options...]
```
Using ```--rm``` instead of ```-d``` makes the container not go background. Stop it by ```CTRL+C```'ing it. We should use the ```--net=host``` option in order to give the launched container acces to host's network stack (this also makes unnecessary to map ports inside the container via the ```-p``` option).

Optional improvement to come:
* Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process.