### PR TITLE
order the client distribution to include the top buckets first

### DIFF
--- a/Jamfile
+++ b/Jamfile
@@ -18,11 +18,10 @@ exe dht-bootstrap
 	<threading>multi
 	<include>src
 	<library>boost-system
-	<toolset>gcc:<cxxflags>-std=c++11
-	<toolset>darwin:<cxxflags>-std=c++11
 	: # default build
 	<link>static
 	<threading>multi
+	<cxxstd>14
 	: # usage requirements
 	;
 
@@ -35,11 +34,10 @@ exe dht-torture
 	<threading>multi
 	<include>src
 	<library>boost-system
-	<toolset>gcc:<cxxflags>-std=c++11
-	<toolset>darwin:<cxxflags>-std=c++11
 	: # default build
 	<link>static
 	<threading>multi
+	<cxxstd>14
 	: # usage requirements
 	;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,11 +177,12 @@ void print_stats(steady_timer& stats_timer, error_code const& ec)
 		}
 		client_histogram.clear();
 	}
-	std::sort(ordered.begin(), ordered.end());
-	char client_dist[200];
+	std::sort(ordered.begin(), ordered.end(), std::greater<>{});
+	char client_dist[250];
 	client_dist[0] = '\0';
 	int len = 0;
 	for (auto i : ordered) {
+		if (len > sizeof(client_dist) - 10) break;
 		len += snprintf(client_dist + len, sizeof(client_dist) - len
 			, "[%c%c: %d] ", (i.second >> 8) & 0xff, i.second & 0xff, i.first);
 	}


### PR DESCRIPTION
Change default build to use C++14 (mostly because the `greater<>` specialization is new in C++14)